### PR TITLE
Use main window font and font size for chat window.

### DIFF
--- a/src/scripts/chat/chat.lua
+++ b/src/scripts/chat/chat.lua
@@ -10,7 +10,8 @@ function lotj.chat.setup()
       autoWrap = false,
       color = "black",
       scrollBar = true,
-      fontSize = 12,
+      font = getFont(),
+      fontSize = getFontSize(),
     }, contentsContainer)
 
   -- Set the wrap at a few characters short of the full width to avoid the scroll bar showing over text


### PR DESCRIPTION
Self-explanatory.

This is a better default to have for people who have their text customized.