### PR TITLE
Added number support for dubs to clan capture

### DIFF
--- a/src/triggers/chat/triggers.json
+++ b/src/triggers/chat/triggers.json
@@ -59,7 +59,7 @@
     "name": "clan",
     "patterns": [
       {
-        "pattern": "{.*}<.*>\\[[a-zA-Z' ]+\\][()<>A-Za-z ]*: ",
+        "pattern": "{.*}<.*>\\[[a-zA-Z'0-9 ]+\\][()<>A-Za-z ]*: ",
         "type": "regex"
       },
       {


### PR DESCRIPTION
I noticed that one of my clannies wasn't being captured, and it's because I had dubbed her disguise with a number, and the clan capture wasn't set up to handle that.

I simply added a 0-9 to the regex string to correct it. I checked other captures and they should be immune to the same bug.