### PR TITLE
Included comma to catch unfamiliar dialects

### DIFF
--- a/src/triggers/chat/triggers.json
+++ b/src/triggers/chat/triggers.json
@@ -3,11 +3,11 @@
     "name": "local",
     "patterns": [
       {
-        "pattern": "^.+ (says|asks|exclaims|whispers)( .+)? '.*'$",
+        "pattern": "^.+ (says|asks|exclaims|whispers)(,? .+)? '.*'$",
         "type": "regex"
       },
       {
-        "pattern": "^'.*' .+ (says|asks|exclaims)( .+)?.$",
+        "pattern": "^'.*' .+ (says|asks|exclaims)(,? .+)?.$",
         "type": "regex"
       },
       {


### PR DESCRIPTION
I noticed that anyone speaking a language my character didn't know didn't get pulled into the local chat window. I figured out it was just a missing comma because of the space. I made it optional and now it's being captured.