### PR TITLE
Another clan capture fix

### DIFF
--- a/src/triggers/chat/triggers.json
+++ b/src/triggers/chat/triggers.json
@@ -59,7 +59,7 @@
     "name": "clan",
     "patterns": [
       {
-        "pattern": "{.*}<.*>\\[[a-zA-Z'0-9 ]+\\][()<>A-Za-z ]*: ",
+        "pattern": "{.*}<.*>\\[[a-zA-Z'0-9- ]+\\][()<>A-Za-z ]*: ",
         "type": "regex"
       },
       {


### PR DESCRIPTION
Noticed that if the person had a hyphen in their name, it wasn't being captured.