### PR TITLE
Chat capture for droids, locally spoken language.

### DIFF
--- a/src/triggers/chat/triggers.json
+++ b/src/triggers/chat/triggers.json
@@ -11,11 +11,11 @@
         "type": "regex"
       },
       {
-        "pattern": "^You( .+)? (say|ask|exclaim|whisper)( .+)? '.*'$",
+        "pattern": "^You( .+)? (say|ask|exclaim|whisper)(,? .+)? '.*'$",
         "type": "regex"
       },
       {
-        "pattern": "^'.*' you( .+)? (say|ask|exclaim)( .+)?.$",
+        "pattern": "^'.*' you( .+)? (say|ask|exclaim)(,? .+)?.$",
         "type": "regex"
       },
       {
@@ -77,7 +77,7 @@
     "name": "ooc",
     "patterns": [
       {
-        "pattern": "^\\((OOC|IMM|RPC|NEWBIE)\\) [#*]?[A-Za-z0-9()]+: .*$",
+        "pattern": "^\\((OOC|IMM|RPC|NEWBIE)\\) [#*]?[\\w\\-()]+: .*$",
         "type": "regex"
       }
     ],


### PR DESCRIPTION
Fixes chat capture for:
1. Droid names in OOC (`(OOC) A1-B2: test.`)
2. Own local speech when using a language (`You say, in Jawa 'test'`)