### PR TITLE
Make autoresearch work even if there are no feats in the practice command output

### DIFF
--- a/src/triggers/autoresearch/autoresearch.practiceEnd.lua
+++ b/src/triggers/autoresearch/autoresearch.practiceEnd.lua
@@ -1,5 +1,4 @@
-if lotj.autoResearch.startOnPracticeEnd then
-  lotj.autoResearch.startOnPracticeEnd = false
+if lotj.autoResearch.enabled then
   echo("\n")
   lotj.autoResearch.initialCount = #(lotj.autoResearch.researchList or {})
   if lotj.autoResearch.initialCount == 0 then

--- a/src/triggers/autoresearch/autoresearch.practiceEnd.lua
+++ b/src/triggers/autoresearch/autoresearch.practiceEnd.lua
@@ -1,4 +1,10 @@
-if lotj.autoResearch.enabled then
+if lotj.autoResearch.started then
+lotj.autoResearch.log("You are already researching..", true)
+elseif lotj.autoResearch.enabled then
+  -- Disable the practice-adding logic
+  disableTrigger("autoresearch.grabSkills")
+  lotj.autoResearch.started = true;
+
   echo("\n")
   lotj.autoResearch.initialCount = #(lotj.autoResearch.researchList or {})
   if lotj.autoResearch.initialCount == 0 then

--- a/src/triggers/autoresearch/triggers.json
+++ b/src/triggers/autoresearch/triggers.json
@@ -37,7 +37,7 @@
             "type": "regex"
           }
         ],
-        "script": "lotj.autoResearch.startOnPracticeEnd = true; disableTrigger(\"autoresearch.grabSkills\")"
+        "script": "disableTrigger(\"autoresearch.grabSkills\")"
       }
     ]
   },


### PR DESCRIPTION
+ Autoresearch works even if you the Feat section is missing from the practice output
+ Autoresearch will no longer add output of the practice command to the research dictionary after the `autoresearch start` command is completed