### PR TITLE
Update autoresearch.next conditions

### DIFF
--- a/src/triggers/autoresearch/triggers.json
+++ b/src/triggers/autoresearch/triggers.json
@@ -79,6 +79,10 @@
       {
         "pattern": "^You cannot learn more about that from books.$",
         "type": "regex"
+      },
+      {
+        "pattern": "^You can't learn more about that from books.$",
+        "type": "regex"
       }
     ],
     "script": "if lotj.autoResearch.enabled then echo(\"\\n\"); expandAlias(\"autoresearch next\", false) end"


### PR DESCRIPTION
Adding additional fire condition for autoresearch.next:
"^You can't learn more about that from books.$"

Skills affected: Flurry
![Mudlet_dIdHdUnHC0](https://github.com/user-attachments/assets/904fc1a2-c2e4-49ea-9946-2e5cc174ade7)
